### PR TITLE
Fix race conditions when using listeners for connection state

### DIFF
--- a/packages/javascript/src/AudioPlayer.ts
+++ b/packages/javascript/src/AudioPlayer.ts
@@ -2,7 +2,7 @@ import { Howl, Howler } from 'howler';
 import CogsConnection from './CogsConnection';
 import { ActiveClip, AudioClip, AudioState } from './types/AudioState';
 import MediaClipStateMessage, { MediaStatus } from './types/MediaClipStateMessage';
-import CogsClientMessage, { Media } from './types/CogsClientMessage';
+import { Media, MediaClientConfig } from './types/CogsClientMessage';
 
 const DEBUG = false;
 
@@ -17,8 +17,6 @@ interface HowlWithHTMLSounds extends Howl {
 interface InternalClipPlayer extends AudioClip {
   player: HowlWithHTMLSounds;
 }
-
-type MediaClientConfigMessage = Extract<CogsClientMessage, { type: 'media_config_update' }>;
 
 type EventTypes = {
   state: AudioState;
@@ -440,7 +438,7 @@ export default class AudioPlayer {
     this.sinkId = sinkId;
   }
 
-  private updateConfig(newFiles: MediaClientConfigMessage['files']) {
+  private updateConfig(newFiles: MediaClientConfig['files']) {
     const newAudioFiles = Object.fromEntries(
       Object.entries(newFiles).filter((file): file is [string, Extract<Media, { type: 'audio' }>] => {
         const type = file[1].type;
@@ -588,6 +586,7 @@ function setPlayerSinkId(player: HowlWithHTMLSounds, sinkId: string | undefined)
  * This doesn't work on iOS (volume is read-only) so at least mute it if the volume is zero
  */
 function setAudioPlayerVolume(howl: HowlWithHTMLSounds, volume: number, soundId: number) {
+  log('Setting volume', volume, soundId);
   howl.volume(volume, soundId);
   howl.mute(volume === 0, soundId);
 }

--- a/packages/javascript/src/VideoPlayer.ts
+++ b/packages/javascript/src/VideoPlayer.ts
@@ -1,15 +1,13 @@
-import CogsConnection from './CogsConnection';
-import { ActiveVideoClipState, VideoClip, VideoState } from './types/VideoState';
-import MediaClipStateMessage, { MediaStatus } from './types/MediaClipStateMessage';
-import CogsClientMessage from './types/CogsClientMessage';
 import { MediaObjectFit } from '.';
+import CogsConnection from './CogsConnection';
+import { MediaClientConfig } from './types/CogsClientMessage';
+import MediaClipStateMessage, { MediaStatus } from './types/MediaClipStateMessage';
+import { ActiveVideoClipState, VideoClip, VideoState } from './types/VideoState';
 
 interface InternalClipPlayer extends VideoClip {
   videoElement: HTMLVideoElement;
   volume: number;
 }
-
-type MediaClientConfigMessage = Extract<CogsClientMessage, { type: 'media_config_update' }>;
 
 type EventTypes = {
   state: VideoState;
@@ -253,7 +251,7 @@ export default class VideoPlayer {
     this.sinkId = sinkId;
   }
 
-  private updateConfig(newPaths: MediaClientConfigMessage['files']) {
+  private updateConfig(newPaths: MediaClientConfig['files']) {
     const newVideoPaths = Object.fromEntries(Object.entries(newPaths).filter(([, { type }]) => type === 'video' || !type));
 
     const previousClipPlayers = this.videoClipPlayers;

--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -1,6 +1,6 @@
 export { default as CogsConnection } from './CogsConnection';
 export * from './CogsConnection';
-export { default as CogsClientMessage } from './types/CogsClientMessage';
+export { default as CogsClientMessage, MediaClientConfig } from './types/CogsClientMessage';
 export { default as MediaClipStateMessage } from './types/MediaClipStateMessage';
 export { default as ShowPhase } from './types/ShowPhase';
 export { default as MediaObjectFit } from './types/MediaObjectFit';

--- a/packages/javascript/src/types/CogsClientMessage.ts
+++ b/packages/javascript/src/types/CogsClientMessage.ts
@@ -45,8 +45,11 @@ export type Media =
       preload: boolean | 'auto' | 'metadata' | 'none';
     };
 
-interface MediaClientConfigMessage {
+export interface MediaClientConfigMessage extends MediaClientConfig {
   type: 'media_config_update';
+}
+
+export interface MediaClientConfig {
   globalVolume: number;
   audioOutput?: string;
   files: {

--- a/packages/react/src/hooks/useCogsConfig.ts
+++ b/packages/react/src/hooks/useCogsConfig.ts
@@ -8,9 +8,11 @@ export default function useCogsConfig<
   const [config, setConfig] = useState<Connection['config']>(connection.config);
 
   useEffect(() => {
+    // Use the latest config in case it has changed before this useEffect ran
+    setConfig(connection.config);
+
     const listener = (event: CogsConfigChangedEvent<Connection['config']>) => setConfig(event.config);
     connection.addEventListener('config', listener);
-    setConfig(connection.config); // Use the latest config in case is has changed before this useEffect ran
     return () => connection.removeEventListener('config', listener);
   }, [connection]);
 

--- a/packages/react/src/hooks/useCogsMediaConfig.ts
+++ b/packages/react/src/hooks/useCogsMediaConfig.ts
@@ -2,7 +2,7 @@ import { CogsConnection, MediaClientConfig } from '@clockworkdog/cogs-client';
 import { useEffect, useState } from 'react';
 
 export default function useCogsMediaConfig<
-  MediaConfigExtra extends unknown = Record<never, never>,
+  MediaConfigExtra,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 >(connection: CogsConnection<any>): (MediaClientConfig & MediaConfigExtra) | null {
   const [mediaConfig, setMediaConfig] = useState<(MediaClientConfig & MediaConfigExtra) | null>(null);

--- a/packages/react/src/hooks/useCogsMediaConfig.ts
+++ b/packages/react/src/hooks/useCogsMediaConfig.ts
@@ -1,0 +1,23 @@
+import { CogsConnection, MediaClientConfig } from '@clockworkdog/cogs-client';
+import { useEffect, useState } from 'react';
+
+export default function useCogsMediaConfig<
+  MediaConfigExtra extends unknown = Record<never, never>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+>(connection: CogsConnection<any>): (MediaClientConfig & MediaConfigExtra) | null {
+  const [mediaConfig, setMediaConfig] = useState<(MediaClientConfig & MediaConfigExtra) | null>(null);
+
+  useEffect(() => {
+    // Use the latest config in case it has changed before this useEffect ran
+    setMediaConfig(connection.mediaConfig as MediaClientConfig & MediaConfigExtra);
+
+    const listener = ({ mediaConfig }: { mediaConfig: MediaClientConfig }) => {
+      setMediaConfig(mediaConfig as MediaClientConfig & MediaConfigExtra);
+    };
+
+    connection.addEventListener('mediaConfig', listener);
+    return () => connection.removeEventListener('mediaConfig', listener);
+  }, [connection]);
+
+  return mediaConfig;
+}

--- a/packages/react/src/hooks/useCogsStateValue.ts
+++ b/packages/react/src/hooks/useCogsStateValue.ts
@@ -10,6 +10,9 @@ export default function useCogsStateValue<
   const [value, setValue] = useState<ManifestTypes.StateValue<ManifestFromConnection<Connection>, Name>>(connection.state[stateName]);
 
   useEffect(() => {
+    // Use the latest state in case it has changed before this useEffect ran
+    setValue(connection.state[stateName]);
+
     const listener = ({ state }: CogsStateChangedEvent<Partial<ManifestTypes.StateAsObject<ManifestFromConnection<Connection>>>>) => {
       const value = state[stateName];
       if (value !== undefined) {

--- a/packages/react/src/hooks/useCogsStateValues.ts
+++ b/packages/react/src/hooks/useCogsStateValues.ts
@@ -8,7 +8,9 @@ export default function useCogsInputPortValues<
   const [value, setValue] = useState<Connection['state']>(connection.state);
 
   useEffect(() => {
+    // Use the latest state in case it has changed before this useEffect ran
     setValue(connection.state);
+
     const listener = () => setValue(connection.state);
     connection.addEventListener('state', listener);
     return () => connection.removeEventListener('state', listener);

--- a/packages/react/src/hooks/useShowPhase.ts
+++ b/packages/react/src/hooks/useShowPhase.ts
@@ -1,6 +1,5 @@
-import { CogsClientMessage, CogsConnection, ShowPhase } from '@clockworkdog/cogs-client';
-import { useCallback, useState } from 'react';
-import useCogsMessage from './useCogsMessage';
+import { CogsConnection, ShowPhase } from '@clockworkdog/cogs-client';
+import { useEffect, useState } from 'react';
 
 export default function useShowPhase<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -8,14 +7,14 @@ export default function useShowPhase<
 >(connection: Connection): ShowPhase {
   const [status, setStatus] = useState(connection.showPhase);
 
-  useCogsMessage(
-    connection,
-    useCallback((message: CogsClientMessage) => {
-      if (message.type === 'show_phase') {
-        setStatus(message.phase);
-      }
-    }, []),
-  );
+  useEffect(() => {
+    // Use the latest show phase in case it has changed before this useEffect ran
+    setStatus(connection.showPhase);
+
+    const listener = () => setStatus(connection.showPhase);
+    connection.addEventListener('showPhase', listener);
+    return () => connection.removeEventListener('showPhase', listener);
+  }, [connection]);
 
   return status;
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,7 @@ export { default as useIsConnected } from './hooks/useIsConnected';
 export { default as useCogsConfig } from './hooks/useCogsConfig';
 export { default as useCogsEvent } from './hooks/useCogsEvent';
 export { default as useCogsEvents } from './hooks/useCogsEvents';
+export { default as useCogsMediaConfig } from './hooks/useCogsMediaConfig';
 export { default as useCogsStateValue } from './hooks/useCogsStateValue';
 export { default as useCogsStateValues } from './hooks/useCogsStateValues';
 export { default as useCogsMessage } from './hooks/useCogsMessage';


### PR DESCRIPTION
This change fixes possible race conditions which can lead to updates from COGS being missed. This has been observed when the media config update is missed which means a client can render an incorrect background until any config change is made in COGS (which then forces the config to be re-sent to the client)

- Persist media config so that the latest can always be accessed on the `CogsConnection` object.
- New event listeners for media config and show phase
- Fix React `use` hooks where appropriate to make sure an update can't be missed between the first render and when the `useEffect` that sets up the listener is executed.