### PR TITLE
Add the ability to set the initial connection state and store values from the React SDK

### DIFF
--- a/packages/javascript/README.md
+++ b/packages/javascript/README.md
@@ -150,7 +150,7 @@ function sendPortUpdateToCogs() {
 You can save arbitrary data to COGS which will be restored when reconnecting with COGS:
 
 ```ts
-const cogsConnection = new CogsConnection(manifest, {
+const cogsConnection = new CogsConnection(manifest, undefined, undefined, {
   // Initial items in the store
   'my-key': { foo: 0, bar: '' },
 });

--- a/packages/react/src/providers/CogsConnectionProvider.tsx
+++ b/packages/react/src/providers/CogsConnectionProvider.tsx
@@ -1,4 +1,4 @@
-import { CogsAudioPlayer, CogsConnection, CogsPluginManifest, CogsVideoPlayer } from '@clockworkdog/cogs-client';
+import { CogsAudioPlayer, CogsConnection, CogsPluginManifest, CogsVideoPlayer, ManifestTypes } from '@clockworkdog/cogs-client';
 import React, { ReactNode, useContext, useEffect, useRef, useState } from 'react';
 
 type CogsConnectionContextValue<Manifest extends CogsPluginManifest> = {
@@ -77,13 +77,18 @@ const CogsConnectionContext = React.createContext<CogsConnectionContextValue<any
  * }
  * ```
  */
-export default function CogsConnectionProvider<Manifest extends CogsPluginManifest>({
+export default function CogsConnectionProvider<
+  Manifest extends CogsPluginManifest,
+  DataT extends { [key: string]: unknown } = { [key: string]: unknown },
+>({
   manifest,
   hostname,
   port,
   children,
   audioPlayer,
   videoPlayer,
+  initialClientState,
+  initialDataStoreData,
 }: {
   manifest: Manifest;
   hostname?: string;
@@ -91,19 +96,21 @@ export default function CogsConnectionProvider<Manifest extends CogsPluginManife
   children: React.ReactNode;
   audioPlayer?: boolean;
   videoPlayer?: boolean;
+  initialClientState?: Partial<ManifestTypes.StateAsObject<Manifest, { writableFromClient: true }>>;
+  initialDataStoreData?: DataT;
 }): ReactNode | null {
   const connectionRef = useRef<CogsConnection<Manifest>>(undefined);
   const [, forceRender] = useState({});
 
   useEffect(() => {
-    const connection = new CogsConnection(manifest, { hostname, port });
+    const connection = new CogsConnection(manifest, { hostname, port }, initialClientState, initialDataStoreData);
     connectionRef.current = connection;
     forceRender({});
     return () => {
       connectionRef.current = undefined;
       connection.close();
     };
-  }, [manifest, hostname, port]);
+  }, [manifest, hostname, port, initialClientState, initialDataStoreData]);
 
   const audioPlayerRef = useRef<CogsAudioPlayer>(undefined);
   useEffect(() => {


### PR DESCRIPTION
Previously this was only possible directly from the JavaScript SDK.

I also corrected the documentation for the JS SDK as it didn't take into account the other constructor parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for providing initial client state and initial data store values when creating a connection in React components.

- **Documentation**
  - Updated example code to reflect the new way of supplying initial store data to the connection constructor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->