### PR TITLE
Improved playback recovery

### DIFF
--- a/packages/javascript/cypress/component/AudioStability.cy.ts
+++ b/packages/javascript/cypress/component/AudioStability.cy.ts
@@ -18,7 +18,8 @@ describe('Audio stability tests', () => {
     });
     cy.mount(manager);
 
-    cy.get('audio').should('have.prop', 'paused', true);
+    cy.get('audio').should('have.prop', 'currentTime', 0);
+    cy.wait(500);
     cy.get('audio').should('have.prop', 'currentTime', 0);
   });
 
@@ -46,7 +47,7 @@ describe('Audio stability tests', () => {
     cy.get('audio').invoke('prop', 'currentTime').should('be.greaterThan', 1.5);
   });
 
-  it('recovers from a play', () => {
+  it('recovers from a playbackRate change', () => {
     const now = Date.now();
     const manager = new SurfaceManager(constructAssetURL, getAudioOutput, {
       'clip-id': {
@@ -64,10 +65,9 @@ describe('Audio stability tests', () => {
       .should(($time) => expect(parseFloat($time)).to.be.closeTo(1.5, 0.1));
 
     cy.log('Interfere with audio element');
-    cy.get('audio').invoke('prop', 'paused').should('be.true');
+    cy.get('audio').invoke('prop', 'playbackRate').should('equal', 0);
     cy.get('audio').invoke('prop', 'playbackRate', 1);
     cy.get('audio').then(($audio) => $audio.get(0).play().catch(/* do nothing*/));
-    cy.get('audio').invoke('prop', 'paused').should('be.false');
 
     cy.wait(1000);
 
@@ -75,6 +75,7 @@ describe('Audio stability tests', () => {
     cy.get('audio')
       .invoke('prop', 'currentTime')
       .should(($time) => expect(parseFloat($time)).to.be.closeTo(1.5, 0.1));
+    cy.get('audio').invoke('prop', 'playbackRate').should('equal', 0);
   });
 
   it('recovers from a seek', () => {

--- a/packages/javascript/cypress/component/VideoStability.cy.ts
+++ b/packages/javascript/cypress/component/VideoStability.cy.ts
@@ -19,7 +19,8 @@ describe('Video stability tests', () => {
     });
     cy.mount(manager);
 
-    cy.get('video').should('have.prop', 'paused', true);
+    cy.get('video').should('have.prop', 'currentTime', 0);
+    cy.wait(500);
     cy.get('video').should('have.prop', 'currentTime', 0);
   });
 
@@ -48,7 +49,7 @@ describe('Video stability tests', () => {
     cy.get('video').invoke('prop', 'currentTime').should('be.greaterThan', 1.5);
   });
 
-  it('recovers from a play', () => {
+  it('recovers from a playbackRate change', () => {
     const now = Date.now();
     const manager = new SurfaceManager(constructAssetURL, getAudioOutput, {
       'clip-id': {
@@ -67,10 +68,9 @@ describe('Video stability tests', () => {
       .should(($time) => expect(parseFloat($time)).to.be.closeTo(1.5, 0.1));
 
     cy.log('Interfere with video element');
-    cy.get('video').invoke('prop', 'paused').should('be.true');
+    cy.get('video').invoke('prop', 'playbackRate').should('equal', 0);
     cy.get('video').invoke('prop', 'playbackRate', 1);
     cy.get('video').then(($video) => $video.get(0).play().catch(/* do nothing*/));
-    cy.get('video').invoke('prop', 'paused').should('be.false');
 
     cy.wait(1000);
 
@@ -78,6 +78,7 @@ describe('Video stability tests', () => {
     cy.get('video')
       .invoke('prop', 'currentTime')
       .should(($time) => expect(parseFloat($time)).to.be.closeTo(1.5, 0.1));
+    cy.get('video').invoke('prop', 'playbackRate').should('equal', 0);
   });
 
   it('recovers from a seek', () => {

--- a/packages/javascript/src/state-based/MediaClipManager.ts
+++ b/packages/javascript/src/state-based/MediaClipManager.ts
@@ -191,8 +191,20 @@ export function assertAudialProperties(mediaElement: HTMLMediaElement, propertie
   }
 }
 
+/*
+ * When playbackRate adjustment is disabled (no-sync) we will attempt to seek-ahead, then wait to play.
+ *  - This is a recovery situation, so we only do it when 2s out of sync. (outer threshold)
+ *  - We seek 1s into the future to allow a lot of buffering time (target)
+ *  - We press play 0.1s early (inner threshold)
+ */
+const NO_SYNC_SEEK_AHEAD_OUTER_THRESHOLD_MS = 2_000;
+const NO_SYNC_SEEK_AHEAD_TARGET_MS = 1_000;
+const NO_SYNC_SEEK_AHEAD_INNER_THRESHOLD_MS = 100;
+
+/*
+ * When playbackRate adjustment is enabled (sync) we will attempt to
+ */
 const OUTER_TARGET_SYNC_THRESHOLD_MS = 50; // When outside of this range we attempt to sync playback
-const OUTER_TARGET_SYNC_NO_PLAYBACK_RATE_ADJUSTMENT_THRESHOLD_MS = 500; // When outside of this range we attempt to sync playback (when playback rate adjustment not allowed)
 const INNER_TARGET_SYNC_THRESHOLD_MS = 5; // When attempting to sync playback, we aim for this accuracy
 const MAX_SYNC_THRESHOLD_MS = 1_000; // If we are further than this, we will seek instead
 const SEEK_LOOKAHEAD_MS = 5; // If it takes time to seek, we should seek ahead a little
@@ -203,10 +215,23 @@ function playbackSmoothing(deltaTime: number) {
   return Math.sign(deltaTime) * Math.pow(Math.abs(deltaTime) / MAX_SYNC_THRESHOLD_MS, PLAYBACK_ADJUSTMENT_SMOOTHING) * MAX_PLAYBACK_RATE_ADJUSTMENT;
 }
 
-interface TemporalSyncState {
-  state: 'idle' | 'seeking' | 'intercepting';
+function assertPlaybackRate(mediaElement: HTMLMediaElement, playbackRate: number) {
+  if (mediaElement.playbackRate !== playbackRate) {
+    mediaElement.playbackRate = playbackRate;
+  }
+  // It's more responsive on chromium to set playbackRate to 0 instead of pausing.
+  // It also makes it more responsive to start again.
+  // On iOS it doesn't make a difference, so we may as well.
+  if (mediaElement.paused) {
+    mediaElement.play().catch(() => {
+      /* do nothing*/
+    });
+  }
 }
 
+interface TemporalSyncState {
+  state: 'idle' | 'seeking' | 'intercepting' | 'seeking-ahead' | 'seeked-ahead';
+}
 /**
  * Makes sure the media is at the correct time and speed.
  * - If we fall slightly behind, we will lightly adjust the speed to catch up.
@@ -219,12 +244,6 @@ export function assertTemporalProperties(
   syncState: TemporalSyncState,
   disablePlaybackRateAdjustment?: boolean,
 ): TemporalSyncState {
-  if (mediaElement.paused && properties.rate > 0) {
-    mediaElement.play().catch(() => {
-      /* Do nothing, will be tried in next loop */
-    });
-  }
-
   // At the end of the media, is it set back to the start?
   // Sounds like looping to me!
   if (mediaElement.duration) {
@@ -244,30 +263,42 @@ export function assertTemporalProperties(
   const deltaTimeAbs = Math.abs(deltaTime);
 
   switch (true) {
-    case syncState.state === 'idle' && properties.rate > 0 && deltaTimeAbs <= OUTER_TARGET_SYNC_THRESHOLD_MS:
-      // We are on course:
-      //   - The video is within accepted latency of the server time
-      //   - The playback rate is aligned with the server rate
-      if (mediaElement.playbackRate !== properties.rate) {
-        mediaElement.playbackRate = properties.rate;
-      }
+    /**
+     * Seek ahead behavior
+     * When playbackRate adjustment is not enabled we will seek ahead and try to prepare to play.
+     * We'll make sure everything is buffered and ready, then wait until we're on time.
+     * We'll try to press play once and leave it to continue.
+     */
+    case disablePlaybackRateAdjustment && syncState.state === 'idle' && properties.rate > 0 && deltaTimeAbs > NO_SYNC_SEEK_AHEAD_OUTER_THRESHOLD_MS: {
+      // Initiate seek-ahead behavior
+      assertPlaybackRate(mediaElement, 0);
+      const target = properties.t + properties.rate * NO_SYNC_SEEK_AHEAD_TARGET_MS;
+      mediaElement.currentTime = target / 1000;
+      return { state: 'seeking-ahead' };
+    }
+    case syncState.state === 'seeking-ahead' && deltaTime > NO_SYNC_SEEK_AHEAD_INNER_THRESHOLD_MS && mediaElement.seeking === false: {
+      // Has seeked ahead and now waiting ahead of time
+      assertPlaybackRate(mediaElement, 0);
+      return { state: 'seeked-ahead' };
+    }
+    case syncState.state === 'seeked-ahead' && deltaTime < -NO_SYNC_SEEK_AHEAD_INNER_THRESHOLD_MS && mediaElement.seeking === false: {
+      // Has seeked but was too slow
+      console.warn('Failed to seek ahead in time');
       return { state: 'idle' };
-
-    case syncState.state === 'idle' &&
-      properties.rate > 0 &&
-      disablePlaybackRateAdjustment === true &&
-      deltaTimeAbs <= OUTER_TARGET_SYNC_NO_PLAYBACK_RATE_ADJUSTMENT_THRESHOLD_MS:
-      // If we aren't able to adjust playback rate, we are more forgiving
-      // in our "synced" check to avoid the clip being seeked forward
-      // in normal playback where we expect to be a little out of sync
-      // due to network and startup latency
-      if (mediaElement.playbackRate !== properties.rate) {
-        mediaElement.playbackRate = properties.rate;
-      }
+    }
+    case syncState.state === 'seeked-ahead' && deltaTimeAbs <= NO_SYNC_SEEK_AHEAD_INNER_THRESHOLD_MS: {
+      // Has waited and now in time
+      assertPlaybackRate(mediaElement, properties.rate);
       return { state: 'idle' };
+    }
 
-    case syncState.state === 'idle' &&
-      disablePlaybackRateAdjustment !== true && // Never adjust playback rate if disabled for this clip
+    /**
+     * Time synchronization behavior
+     * When playbackRate adjustment is enabled we will address small deviations in time by ramping speed up and down.
+     * We address larger deviations with a seek, hoping to land close enough so we can finely adjust with playbackRate.
+     */
+    case !disablePlaybackRateAdjustment &&
+      syncState.state === 'idle' &&
       properties.rate > 0 &&
       deltaTimeAbs > OUTER_TARGET_SYNC_THRESHOLD_MS &&
       deltaTimeAbs <= MAX_SYNC_THRESHOLD_MS: {
@@ -276,18 +307,14 @@ export function assertTemporalProperties(
       //  - We must be close in time to the server time
       const playbackRateAdjustment = playbackSmoothing(deltaTime);
       const adjustedPlaybackRate = Math.max(0, properties.rate - playbackRateAdjustment);
-      if (mediaElement.playbackRate !== adjustedPlaybackRate) {
-        mediaElement.playbackRate = adjustedPlaybackRate;
-      }
+      assertPlaybackRate(mediaElement, adjustedPlaybackRate);
 
       return { state: 'intercepting' };
     }
 
     case syncState.state === 'intercepting' && properties.rate > 0 && deltaTimeAbs <= INNER_TARGET_SYNC_THRESHOLD_MS: {
       // We have intercepted, we can now play normally
-      if (mediaElement.playbackRate !== properties.rate) {
-        mediaElement.playbackRate = properties.rate;
-      }
+      assertPlaybackRate(mediaElement, properties.rate);
       return { state: 'idle' };
     }
 
@@ -303,14 +330,27 @@ export function assertTemporalProperties(
       return { state: 'seeking' };
     }
 
+    /**
+     * Default idle playback
+     */
+    case syncState.state === 'idle':
+      assertPlaybackRate(mediaElement, properties.rate);
+
+      console.log(deltaTime.toFixed(1));
+      return { state: 'idle' };
+
+    // default: {
+    //   // We cannot smoothly recover:
+    //   //  - We seek just ahead of server time
+    //   if (mediaElement.playbackRate !== properties.rate) {
+    //     mediaElement.playbackRate = properties.rate;
+    //   }
+    //   mediaElement.currentTime = (properties.t + properties.rate * SEEK_LOOKAHEAD_MS) / 1000;
+    //   return { state: 'seeking' };
+    // }
     default: {
-      // We cannot smoothly recover:
-      //  - We seek just ahead of server time
-      if (mediaElement.playbackRate !== properties.rate) {
-        mediaElement.playbackRate = properties.rate;
-      }
-      mediaElement.currentTime = (properties.t + properties.rate * SEEK_LOOKAHEAD_MS) / 1000;
-      return { state: 'seeking' };
+      console.log(deltaTime.toFixed(1));
+      return syncState;
     }
   }
 }
@@ -375,15 +415,7 @@ export class AudioManager extends MediaClipManager<AudioState> {
       this.syncState,
       this._state.disablePlaybackRateAdjustment,
     );
-    if (this.syncState.state !== 'seeking' && nextSyncState.state === 'seeking') {
-      this.audioElement.addEventListener(
-        'seeked',
-        () => {
-          this.syncState = { state: 'idle' };
-        },
-        { passive: true, once: true },
-      );
-    }
+    console.log(nextSyncState);
 
     this.syncState = nextSyncState;
   }
@@ -431,15 +463,7 @@ export class VideoManager extends MediaClipManager<VideoState> {
       this.syncState,
       this._state.disablePlaybackRateAdjustment,
     );
-    if (this.syncState.state !== 'seeking' && nextSyncState.state === 'seeking') {
-      this.videoElement.addEventListener(
-        'seeked',
-        () => {
-          this.syncState = { state: 'idle' };
-        },
-        { passive: true, once: true },
-      );
-    }
+    console.log(nextSyncState);
 
     this.syncState = nextSyncState;
   }

--- a/packages/javascript/src/state-based/MediaClipManager.ts
+++ b/packages/javascript/src/state-based/MediaClipManager.ts
@@ -10,6 +10,7 @@ import {
 } from '../types/MediaSchema';
 import { getStateAtTime } from '../utils/getStateAtTime';
 import { IS_IOS } from '../utils/device';
+import { modulo, moduloDiff } from '../utils/modulo';
 import { MediaPreloader } from './MediaPreloader';
 
 const getPath = (url: string): string | undefined => {
@@ -252,12 +253,13 @@ export function assertTemporalProperties(
 ): TemporalSyncState {
   // At the end of the media, is it set back to the start?
   // Sounds like looping to me!
+  let isLooping = false;
   if (mediaElement.duration) {
     const nextTemporalKeyframe = keyframes.filter(([t, kf]) => t > properties.t && (kf?.set?.t !== undefined || kf?.set?.rate !== undefined))[0];
     if (nextTemporalKeyframe?.[1]?.set?.t === 0) {
       const timeRemaining = (mediaElement.duration - properties.t) / properties.rate;
       const timeUntilKeyframe = nextTemporalKeyframe[0] - properties.t;
-      const isLooping = Math.abs(timeRemaining - timeUntilKeyframe) <= LOOPING_EPSILON_MS;
+      isLooping = Math.abs(timeRemaining - timeUntilKeyframe) <= LOOPING_EPSILON_MS;
       if (mediaElement.loop !== isLooping) {
         mediaElement.loop = isLooping;
       }
@@ -265,7 +267,10 @@ export function assertTemporalProperties(
   }
 
   const currentTime = mediaElement.currentTime * 1000;
-  const deltaTime = currentTime - properties.t;
+  const deltaTime =
+    isLooping && mediaElement.duration !== undefined
+      ? moduloDiff(currentTime, properties.t, mediaElement.duration * 1000)
+      : currentTime - properties.t;
   const deltaTimeAbs = Math.abs(deltaTime);
 
   switch (true) {
@@ -276,9 +281,13 @@ export function assertTemporalProperties(
      * We'll try to press play once and leave it to continue.
      */
     case disablePlaybackRateAdjustment && syncState.state === 'idle' && properties.rate > 0 && deltaTimeAbs > NO_SYNC_SEEK_AHEAD_OUTER_THRESHOLD_MS: {
+      const target = (properties.t + properties.rate * NO_SYNC_SEEK_LOOKAHEAD_MS) / 1000;
+      if (mediaElement.duration !== undefined && target > mediaElement.duration && !isLooping) {
+        // We're not looping, and this is past the end of the video
+        return { state: 'idle' };
+      }
       assertPlaybackRate(mediaElement, 0);
-      const target = properties.t + properties.rate * NO_SYNC_SEEK_LOOKAHEAD_MS;
-      mediaElement.currentTime = target / 1000;
+      mediaElement.currentTime = isLooping ? modulo(target, mediaElement.duration * 1000) : target;
       return { state: 'seeking-ahead' };
     }
     case syncState.state === 'seeking-ahead' && mediaElement.seeking === true:
@@ -289,11 +298,16 @@ export function assertTemporalProperties(
       return { state: 'seeked-ahead' };
     }
     case syncState.state === 'seeked-ahead' && deltaTime < -NO_SYNC_SEEK_AHEAD_INNER_THRESHOLD_MS: {
+      assertPlaybackRate(mediaElement, properties.rate);
       console.warn('Failed to seek ahead in time');
       return { state: 'idle' };
     }
     case syncState.state === 'seeked-ahead' && deltaTimeAbs <= NO_SYNC_SEEK_AHEAD_INNER_THRESHOLD_MS: {
       assertPlaybackRate(mediaElement, properties.rate);
+      return { state: 'idle' };
+    }
+    case syncState.state === 'seeked-ahead' && deltaTimeAbs > NO_SYNC_SEEK_AHEAD_OUTER_THRESHOLD_MS * 1.5: {
+      console.warn('Failed to seek ahead');
       return { state: 'idle' };
     }
     case syncState.state === 'seeked-ahead':
@@ -322,6 +336,7 @@ export function assertTemporalProperties(
     }
     // Intercept went too far
     case syncState.state === 'intercepting' && Math.sign(deltaTime) === Math.sign(mediaElement.playbackRate - properties.rate): {
+      assertPlaybackRate(mediaElement, properties.rate);
       return { state: 'idle' };
     }
     // We're still on course
@@ -329,6 +344,7 @@ export function assertTemporalProperties(
       return { state: 'intercepting' };
     // We're way off track
     case syncState.state === 'intercepting':
+      assertPlaybackRate(mediaElement, properties.rate);
       return { state: 'idle' };
 
     /**
@@ -337,8 +353,8 @@ export function assertTemporalProperties(
      * We address larger deviations with a seek, hoping to land close enough so we can finely adjust with playbackRate.
      */
     case !disablePlaybackRateAdjustment && syncState.state === 'idle' && deltaTimeAbs > SYNC_MAX_THRESHOLD_MS: {
-      const seekTarget = properties.t + properties.rate * SYNC_SEEK_LOOKAHEAD_MS;
-      mediaElement.currentTime = seekTarget / 1000;
+      const seekTarget = (properties.t + properties.rate * SYNC_SEEK_LOOKAHEAD_MS) / 1000;
+      mediaElement.currentTime = isLooping ? modulo(seekTarget, mediaElement.duration * 1000) : seekTarget;
       assertPlaybackRate(mediaElement, properties.rate);
       return { state: 'seeking' };
     }

--- a/packages/javascript/src/state-based/MediaClipManager.ts
+++ b/packages/javascript/src/state-based/MediaClipManager.ts
@@ -9,7 +9,7 @@ import {
   VisualProperties,
 } from '../types/MediaSchema';
 import { getStateAtTime } from '../utils/getStateAtTime';
-import { IS_IOS } from '../utils/device';
+import { IS_IOS, IS_WEBKIT } from '../utils/device';
 import { modulo, moduloDiff } from '../utils/modulo';
 import { MediaPreloader } from './MediaPreloader';
 
@@ -251,6 +251,10 @@ export function assertTemporalProperties(
   syncState: TemporalSyncState,
   enablePlaybackRateAdjustment: boolean,
 ): TemporalSyncState {
+  // On Webkit (using the simulator on safari and COGS mobile app on iOS) changes to currentTime and playbackRate are much less responsive.
+  // We make sure we only do lower frequency updates, and don't change playbackRate.
+  const playbackRateSync = enablePlaybackRateAdjustment && !IS_WEBKIT;
+
   // At the end of the media, is it set back to the start?
   // Sounds like looping to me!
   let isLooping = false;
@@ -280,7 +284,7 @@ export function assertTemporalProperties(
      * We'll make sure everything is buffered and ready, then wait until we're on time.
      * We'll try to press play once and leave it to continue.
      */
-    case !enablePlaybackRateAdjustment && syncState.state === 'idle' && properties.rate > 0 && deltaTimeAbs > NO_SYNC_SEEK_AHEAD_OUTER_THRESHOLD_MS: {
+    case !playbackRateSync && syncState.state === 'idle' && properties.rate > 0 && deltaTimeAbs > NO_SYNC_SEEK_AHEAD_OUTER_THRESHOLD_MS: {
       const target = (properties.t + properties.rate * NO_SYNC_SEEK_LOOKAHEAD_MS) / 1000;
       if (mediaElement.duration !== undefined && target > mediaElement.duration && !isLooping) {
         // We're not looping, and this is past the end of the video
@@ -307,6 +311,7 @@ export function assertTemporalProperties(
       return { state: 'idle' };
     }
     case syncState.state === 'seeked-ahead' && deltaTimeAbs > NO_SYNC_SEEK_AHEAD_OUTER_THRESHOLD_MS * 1.5: {
+      // This is an escape mechanism for this behavior.  This may happen if the state changes after we've seeked ahead.
       console.warn('Failed to seek ahead');
       return { state: 'idle' };
     }
@@ -319,7 +324,7 @@ export function assertTemporalProperties(
      * We address larger deviations with a seek, hoping to land close enough so we can finely adjust with playbackRate.
      */
     // Start intercept
-    case enablePlaybackRateAdjustment &&
+    case playbackRateSync &&
       syncState.state === 'idle' &&
       properties.rate > 0 &&
       deltaTimeAbs > SYNC_OUTER_TARGET_THRESHOLD_MS &&
@@ -352,7 +357,7 @@ export function assertTemporalProperties(
      * When playbackRate adjustment is enabled we will address small deviations in time by ramping speed up and down.
      * We address larger deviations with a seek, hoping to land close enough so we can finely adjust with playbackRate.
      */
-    case enablePlaybackRateAdjustment && syncState.state === 'idle' && deltaTimeAbs > SYNC_MAX_THRESHOLD_MS: {
+    case playbackRateSync && syncState.state === 'idle' && deltaTimeAbs > SYNC_MAX_THRESHOLD_MS: {
       const seekTarget = (properties.t + properties.rate * SYNC_SEEK_LOOKAHEAD_MS) / 1000;
       mediaElement.currentTime = isLooping ? modulo(seekTarget, mediaElement.duration * 1000) : seekTarget;
       assertPlaybackRate(mediaElement, properties.rate);

--- a/packages/javascript/src/state-based/MediaClipManager.ts
+++ b/packages/javascript/src/state-based/MediaClipManager.ts
@@ -70,7 +70,7 @@ export abstract class MediaClipManager<T extends MediaClipState> {
     clearTimeout(this.timeout);
     if (this.isConnected()) {
       this.update();
-      this.timeout = setTimeout(this.loop, INNER_TARGET_SYNC_THRESHOLD_MS);
+      this.timeout = setTimeout(this.loop, SYNC_INNER_TARGET_THRESHOLD_MS);
     } else {
       this.destroy();
     }
@@ -194,25 +194,32 @@ export function assertAudialProperties(mediaElement: HTMLMediaElement, propertie
 /*
  * When playbackRate adjustment is disabled (no-sync) we will attempt to seek-ahead, then wait to play.
  *  - This is a recovery situation, so we only do it when 2s out of sync. (outer threshold)
- *  - We seek 1s into the future to allow a lot of buffering time (target)
+ *  - We seek 1s into the future to allow a lot of buffering time (lookahead)
  *  - We press play 0.1s early (inner threshold)
  */
 const NO_SYNC_SEEK_AHEAD_OUTER_THRESHOLD_MS = 2_000;
-const NO_SYNC_SEEK_AHEAD_TARGET_MS = 1_000;
+const NO_SYNC_SEEK_LOOKAHEAD_MS = 1_000;
 const NO_SYNC_SEEK_AHEAD_INNER_THRESHOLD_MS = 100;
 
-/*
- * When playbackRate adjustment is enabled (sync) we will attempt to
+/**
+ * When playbackRate adjustment is enabled (sync) we will attempt to speed ramp to get closer to the correct time.
+ *  - Whenever we are out of sync by an amount we think we can improve (outer threshold)
+ *  - We adjust the playbackRate until we are close enough (inner threshold)
+ *  - If we're too far away that it would take too long to sync (max threshold), then we seek instead.
+ *  - If we seek ahead we may as well attempt to add a little time for buffering (lookahead)
  */
-const OUTER_TARGET_SYNC_THRESHOLD_MS = 50; // When outside of this range we attempt to sync playback
-const INNER_TARGET_SYNC_THRESHOLD_MS = 5; // When attempting to sync playback, we aim for this accuracy
-const MAX_SYNC_THRESHOLD_MS = 1_000; // If we are further than this, we will seek instead
-const SEEK_LOOKAHEAD_MS = 5; // If it takes time to seek, we should seek ahead a little
+const SYNC_OUTER_TARGET_THRESHOLD_MS = 50;
+const SYNC_INNER_TARGET_THRESHOLD_MS = 5;
+const SYNC_MAX_THRESHOLD_MS = 1_000;
+const SYNC_SEEK_LOOKAHEAD_MS = 10;
+
+// If the media is scheduled to go back to the start close in time to the end of the video, we'll use the loop attribute.
 const LOOPING_EPSILON_MS = 5;
+
 const PLAYBACK_ADJUSTMENT_SMOOTHING = 0.3;
 const MAX_PLAYBACK_RATE_ADJUSTMENT = 0.1;
 function playbackSmoothing(deltaTime: number) {
-  return Math.sign(deltaTime) * Math.pow(Math.abs(deltaTime) / MAX_SYNC_THRESHOLD_MS, PLAYBACK_ADJUSTMENT_SMOOTHING) * MAX_PLAYBACK_RATE_ADJUSTMENT;
+  return Math.sign(deltaTime) * Math.pow(Math.abs(deltaTime) / SYNC_MAX_THRESHOLD_MS, PLAYBACK_ADJUSTMENT_SMOOTHING) * MAX_PLAYBACK_RATE_ADJUSTMENT;
 }
 
 function assertPlaybackRate(mediaElement: HTMLMediaElement, playbackRate: number) {
@@ -234,8 +241,7 @@ interface TemporalSyncState {
 }
 /**
  * Makes sure the media is at the correct time and speed.
- * - If we fall slightly behind, we will lightly adjust the speed to catch up.
- * - If we are too far away to smoothly realign, we will seek to the correct time.
+ * - Algorithms and constants defined above
  */
 export function assertTemporalProperties(
   mediaElement: HTMLMediaElement,
@@ -270,87 +276,95 @@ export function assertTemporalProperties(
      * We'll try to press play once and leave it to continue.
      */
     case disablePlaybackRateAdjustment && syncState.state === 'idle' && properties.rate > 0 && deltaTimeAbs > NO_SYNC_SEEK_AHEAD_OUTER_THRESHOLD_MS: {
-      // Initiate seek-ahead behavior
       assertPlaybackRate(mediaElement, 0);
-      const target = properties.t + properties.rate * NO_SYNC_SEEK_AHEAD_TARGET_MS;
+      const target = properties.t + properties.rate * NO_SYNC_SEEK_LOOKAHEAD_MS;
       mediaElement.currentTime = target / 1000;
       return { state: 'seeking-ahead' };
     }
-    case syncState.state === 'seeking-ahead' && deltaTime > NO_SYNC_SEEK_AHEAD_INNER_THRESHOLD_MS && mediaElement.seeking === false: {
-      // Has seeked ahead and now waiting ahead of time
+    case syncState.state === 'seeking-ahead' && mediaElement.seeking === true:
+      return { state: 'seeking-ahead' };
+
+    case syncState.state === 'seeking-ahead' && mediaElement.seeking === false: {
       assertPlaybackRate(mediaElement, 0);
       return { state: 'seeked-ahead' };
     }
-    case syncState.state === 'seeked-ahead' && deltaTime < -NO_SYNC_SEEK_AHEAD_INNER_THRESHOLD_MS && mediaElement.seeking === false: {
-      // Has seeked but was too slow
+    case syncState.state === 'seeked-ahead' && deltaTime < -NO_SYNC_SEEK_AHEAD_INNER_THRESHOLD_MS: {
       console.warn('Failed to seek ahead in time');
       return { state: 'idle' };
     }
     case syncState.state === 'seeked-ahead' && deltaTimeAbs <= NO_SYNC_SEEK_AHEAD_INNER_THRESHOLD_MS: {
-      // Has waited and now in time
       assertPlaybackRate(mediaElement, properties.rate);
       return { state: 'idle' };
     }
+    case syncState.state === 'seeked-ahead':
+      return { state: 'seeked-ahead' };
 
     /**
      * Time synchronization behavior
      * When playbackRate adjustment is enabled we will address small deviations in time by ramping speed up and down.
      * We address larger deviations with a seek, hoping to land close enough so we can finely adjust with playbackRate.
      */
+    // Start intercept
     case !disablePlaybackRateAdjustment &&
       syncState.state === 'idle' &&
       properties.rate > 0 &&
-      deltaTimeAbs > OUTER_TARGET_SYNC_THRESHOLD_MS &&
-      deltaTimeAbs <= MAX_SYNC_THRESHOLD_MS: {
-      // We are close, we can smoothly adjust with playbackRate:
-      //  - The video must be playing
-      //  - We must be close in time to the server time
+      deltaTimeAbs > SYNC_OUTER_TARGET_THRESHOLD_MS &&
+      deltaTimeAbs <= SYNC_MAX_THRESHOLD_MS: {
       const playbackRateAdjustment = playbackSmoothing(deltaTime);
       const adjustedPlaybackRate = Math.max(0, properties.rate - playbackRateAdjustment);
       assertPlaybackRate(mediaElement, adjustedPlaybackRate);
-
       return { state: 'intercepting' };
     }
-
-    case syncState.state === 'intercepting' && properties.rate > 0 && deltaTimeAbs <= INNER_TARGET_SYNC_THRESHOLD_MS: {
-      // We have intercepted, we can now play normally
+    // Perfectly intercepted
+    case syncState.state === 'intercepting' && deltaTimeAbs <= SYNC_INNER_TARGET_THRESHOLD_MS: {
       assertPlaybackRate(mediaElement, properties.rate);
       return { state: 'idle' };
     }
-
+    // Intercept went too far
     case syncState.state === 'intercepting' && Math.sign(deltaTime) === Math.sign(mediaElement.playbackRate - properties.rate): {
-      // We have missed our interception.  Go back to idle to try again.
       return { state: 'idle' };
     }
-
-    case syncState.state === 'intercepting':
+    // We're still on course
+    case syncState.state === 'intercepting' && deltaTimeAbs < SYNC_MAX_THRESHOLD_MS * 2:
       return { state: 'intercepting' };
+    // We're way off track
+    case syncState.state === 'intercepting':
+      return { state: 'idle' };
 
-    case syncState.state === 'seeking': {
+    /**
+     * Time synchronization behavior
+     * When playbackRate adjustment is enabled we will address small deviations in time by ramping speed up and down.
+     * We address larger deviations with a seek, hoping to land close enough so we can finely adjust with playbackRate.
+     */
+    case !disablePlaybackRateAdjustment && syncState.state === 'idle' && deltaTimeAbs > SYNC_MAX_THRESHOLD_MS: {
+      const seekTarget = properties.t + properties.rate * SYNC_SEEK_LOOKAHEAD_MS;
+      mediaElement.currentTime = seekTarget / 1000;
+      assertPlaybackRate(mediaElement, properties.rate);
       return { state: 'seeking' };
+    }
+    case syncState.state === 'seeking' && mediaElement.seeking: {
+      return { state: 'seeking' };
+    }
+    case syncState.state === 'seeking' && !mediaElement.seeking: {
+      return { state: 'idle' };
     }
 
     /**
-     * Default idle playback
+     * Idle behavior
      */
     case syncState.state === 'idle':
       assertPlaybackRate(mediaElement, properties.rate);
-
-      console.log(deltaTime.toFixed(1));
+      if (properties.rate === 0 && deltaTimeAbs > SYNC_OUTER_TARGET_THRESHOLD_MS) {
+        mediaElement.currentTime = properties.t / 1000;
+      }
       return { state: 'idle' };
 
-    // default: {
-    //   // We cannot smoothly recover:
-    //   //  - We seek just ahead of server time
-    //   if (mediaElement.playbackRate !== properties.rate) {
-    //     mediaElement.playbackRate = properties.rate;
-    //   }
-    //   mediaElement.currentTime = (properties.t + properties.rate * SEEK_LOOKAHEAD_MS) / 1000;
-    //   return { state: 'seeking' };
-    // }
+    /**
+     * If none of the above conditions are met, we should exit the behavior.
+     * For example: we are intercepting but the media has now been paused
+     */
     default: {
-      console.log(deltaTime.toFixed(1));
-      return syncState;
+      return { state: 'idle' };
     }
   }
 }
@@ -415,8 +429,6 @@ export class AudioManager extends MediaClipManager<AudioState> {
       this.syncState,
       this._state.disablePlaybackRateAdjustment,
     );
-    console.log(nextSyncState);
-
     this.syncState = nextSyncState;
   }
 
@@ -463,8 +475,6 @@ export class VideoManager extends MediaClipManager<VideoState> {
       this.syncState,
       this._state.disablePlaybackRateAdjustment,
     );
-    console.log(nextSyncState);
-
     this.syncState = nextSyncState;
   }
 

--- a/packages/javascript/src/utils/device.ts
+++ b/packages/javascript/src/utils/device.ts
@@ -1,2 +1,5 @@
 // Check an iOS-only property (See https://developer.mozilla.org/en-US/docs/Web/API/Navigator#non-standard_properties)
 export const IS_IOS = typeof navigator !== 'undefined' && typeof (navigator as { standalone?: boolean }).standalone !== 'undefined';
+
+// https://evilmartians.com/chronicles/how-to-detect-safari-and-ios-versions-with-ease
+export const IS_WEBKIT = 'GestureEvent' in window;

--- a/packages/javascript/src/utils/modulo.test.ts
+++ b/packages/javascript/src/utils/modulo.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { moduloDiff } from './modulo';
+
+describe('moduloDiff()', () => {
+  it('calculates close bounds', () => {
+    expect(moduloDiff(51, 49, 100)).toBe(2);
+    expect(moduloDiff(0, 17, 100)).toBe(-17);
+  });
+  it('calculates wrap-around bounds', () => {
+    expect(moduloDiff(1, 99, 100)).toBe(2);
+    expect(moduloDiff(98, 10, 100)).toBe(-12);
+  });
+  it('calculates from different loops', () => {
+    expect(moduloDiff(2, 101, 100)).toBe(1);
+    expect(moduloDiff(10, 205, 100)).toBe(5);
+    expect(moduloDiff(5, -190, 100)).toBe(-5);
+  });
+});

--- a/packages/javascript/src/utils/modulo.ts
+++ b/packages/javascript/src/utils/modulo.ts
@@ -1,0 +1,18 @@
+/**
+ * Correct modulo operator
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Remainder#description
+ */
+export function modulo(n: number, divisor: number) {
+  return ((n % divisor) + divisor) % divisor;
+}
+
+export function moduloDiff(n: number, m: number, divisor: number) {
+  n = modulo(n, divisor);
+  m = modulo(m, divisor);
+
+  if (Math.abs(n - m) < divisor / 2) {
+    return n - m;
+  } else {
+    return n < m ? n + divisor - m : n - (m + divisor);
+  }
+}


### PR DESCRIPTION
- Improved flow of `assertTemporalProperties`
  - I have separated all the cases into 'behaviors'
  - Each behavior should be initiated from `idle` and should always go back to `idle`
- Added a new behaviour for seeking ahead when playbackRate adjustment is disabled
- Added small optimisation to avoid pausing media
- Removed `seeked` event listners in favour of polling `HTMLMediaElement.seeked`