### PR TITLE
Ensuring Date override always returns integer

### DIFF
--- a/packages/timesync/src/setDate.ts
+++ b/packages/timesync/src/setDate.ts
@@ -6,7 +6,7 @@ const OriginalDateConstructor = globalThis.Date;
  * Patch `Date.now()` and `new Date()` given the current time is @param now
  */
 export function setDate(now: number) {
-  const nowDelta = now - OriginalDateConstructor.now();
+  const nowDelta = Math.round(now - OriginalDateConstructor.now());
 
   function Date(...args: [string | number | Date] | []) {
     if (args.length === 0) {


### PR DESCRIPTION
- I think this is the correct place to perform rounding, as it is only to do with `Date.now()`
- For example the rest of the timesync logic could work with higher precision (`performance.now()`), but only `Date.now()` should be integer.