### PR TITLE
Adding a warning for mismatched COGS and cogs-client versions

### DIFF
--- a/packages/javascript/src/CogsConnection.ts
+++ b/packages/javascript/src/CogsConnection.ts
@@ -167,6 +167,29 @@ export default class CogsConnection<Manifest extends CogsPluginManifest, DataT e
               case 'data_store_items':
                 this.store.handleDataStoreItemsMessage(message);
                 break;
+
+              // From cogs-client@3.0.0 legacy media events are no longer supported.
+              // COGS will continue sending them with an added 'media_strategy' field for backwards compatibility.
+              // If media_strategy is not present, the user is attempting to use a new cogs-client with an old COGS.
+              case 'audio_play':
+              case 'audio_pause':
+              case 'audio_stop':
+              case 'audio_set_clip_volume':
+              case 'video_play':
+              case 'video_pause':
+              case 'video_stop':
+              case 'video_set_volume':
+              case 'video_set_fit':
+              case 'image_show':
+              case 'image_hide':
+              case 'image_set_fit': {
+                const { type } = message;
+                if (!('media_strategy' in message)) {
+                  console.warn(
+                    `Legacy ${type} message received, this is no longer supported.  Please upgrade to COGS 5.10 or downgrade to cogs-client@2.11`,
+                  );
+                }
+              }
             }
 
             this.dispatchEvent(new CogsMessageEvent(message));


### PR DESCRIPTION
- Adds a warning when a COGS instance that doesn't support stateless media sends legacy media events to a new cogs-sdk.

Tested Using `cogs-sdk` on `main` and current COGS in production `5.9`

Action
<img width="498" height="267" alt="Screenshot 2026-05-11 at 14 28 40" src="https://github.com/user-attachments/assets/766c6102-9a3a-4717-806e-84d452181002" />
Leads to console warning
<img width="524" height="52" alt="Screenshot 2026-05-11 at 14 29 01" src="https://github.com/user-attachments/assets/49e67a48-4444-4141-8fb0-8ad2f65562d1" />
(now says `cogs-client` not `cogs-client-react`)
