### PR TITLE
Pinning GH action dependencies

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -20,8 +20,10 @@ jobs:
   test-packages:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # actions/checkout@v6
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
+        # actions/setup-node@v6
+      - uses: actions/setup-node@670825a89dc0abd596e7a3abd0f5e3f6e5faf37c
         with:
           node-version-file: .node-version
           cache: yarn
@@ -41,8 +43,10 @@ jobs:
         working-directory: template
     steps:
       - name: Sparse checkout just the template
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+        # actions/checkout@v6
+        uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
+        # actions/setup-node@v6
+      - uses: actions/setup-node@670825a89dc0abd596e7a3abd0f5e3f6e5faf37c
         with:
           node-version-file: .node-version
       - name: Create an empty yarn.lock in the template folder to allow it to be treated separate from the parent directory project
@@ -75,10 +79,12 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v6
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+        # actions/setup-node@v6
+      - uses: actions/setup-node@670825a89dc0abd596e7a3abd0f5e3f6e5faf37c
         with:
           node-version-file: .node-version
           cache: yarn
@@ -106,8 +112,10 @@ jobs:
     steps:
       - if: ${{ env.ACT }}
         run: apt-get update && apt-get install -y git rsync
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # actions/checkout@v6
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
+        # actions/setup-node@v6
+      - uses: actions/setup-node@670825a89dc0abd596e7a3abd0f5e3f6e5faf37c
         with:
           node-version-file: .node-version
           cache: yarn
@@ -118,7 +126,8 @@ jobs:
       - name: Build docs
         run: yarn run build-docs
       - name: Release docs
-        uses: JamesIves/github-pages-deploy-action@v4
+        # JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f
         with:
           branch: docs
           folder: docs

--- a/template/.github/actions/setup-build-environment/action.yml
+++ b/template/.github/actions/setup-build-environment/action.yml
@@ -5,7 +5,8 @@ runs:
   steps:
     - run: corepack enable
       shell: bash
-    - uses: actions/setup-node@v4
+      # actions/setup-node@v6
+    - uses: actions/setup-node@670825a89dc0abd596e7a3abd0f5e3f6e5faf37c
       with:
         node-version-file: '.node-version'
         cache: yarn

--- a/template/.github/workflows/test.yml
+++ b/template/.github/workflows/test.yml
@@ -19,28 +19,32 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v6
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       - uses: ./.github/actions/setup-build-environment
       - run: yarn run build
 
   check-repo:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v6
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       - uses: ./.github/actions/setup-build-environment
       - run: yarn run check-repo
 
   check-types:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v6
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       - uses: ./.github/actions/setup-build-environment
       - run: yarn run check-types
 
   check-lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v6
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       - uses: ./.github/actions/setup-build-environment
       - run: yarn run check-lint
 
@@ -62,13 +66,15 @@ jobs:
       - tests-complete
     steps:
       # Checkout and run the build
-      - uses: actions/checkout@v4
+      # actions/checkout@v6
+      - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       - uses: ./.github/actions/setup-build-environment
       - run: yarn run build
       # Copy the test-project-pack with symlinks followed and copied
       - run: cp -rL test-project-pack test-project-pack-no-symlinks
       # Upload a zip artifact for this run
-      - uses: actions/upload-artifact@v4
+      # actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ github.event.repository.name }}-${{ github.sha }}
           path: test-project-pack-no-symlinks
@@ -79,7 +85,8 @@ jobs:
           mv test-project-pack-no-symlinks "${{ github.event.repository.name }}-${{ github.ref_name }}"
           zip -r "${{ github.event.repository.name }}-${{ github.ref_name }}.zip" "${{ github.event.repository.name }}-${{ github.ref_name }}"
       - name: Release
-        uses: softprops/action-gh-release@v2
+        # softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         if: github.ref_type == 'tag'
         with:
           files: "${{ github.event.repository.name }}-${{ github.ref_name }}.zip"


### PR DESCRIPTION
- Updating `actions/checkout` and `actions/setup-node` to avoid NodeJS20 EOL
- Pinning GitHub actions