### PR TITLE
Allow JS SDK to be loaded in Node.js

### DIFF
--- a/packages/javascript/src/utils/device.ts
+++ b/packages/javascript/src/utils/device.ts
@@ -2,4 +2,5 @@
 export const IS_IOS = typeof navigator !== 'undefined' && typeof (navigator as { standalone?: boolean }).standalone !== 'undefined';
 
 // https://evilmartians.com/chronicles/how-to-detect-safari-and-ios-versions-with-ease
-export const IS_WEBKIT = 'GestureEvent' in window;
+// We use `globalThis` instead of `window` to allow the library to load in non-browser environments (e.g. Node.js)
+export const IS_WEBKIT = 'GestureEvent' in globalThis;


### PR DESCRIPTION
Resolves the error in Node.js:

```
ReferenceError: window is not defined
    at eval (webpack-internal:///./node_modules/@clockworkdog/cogs-client/dist/utils/device.js:9:37)
    at ./node_modules/@clockworkdog/cogs-client/dist/utils/device.js
```
