### PR TITLE
Utility to validate hostname part of a network access pattern

### DIFF
--- a/packages/javascript/src/utils/NetworkHostPattern.test.ts
+++ b/packages/javascript/src/utils/NetworkHostPattern.test.ts
@@ -111,6 +111,20 @@ describe('NetworkHostPattern', () => {
     });
   });
 
+  describe('validateHostname', () => {
+    it('matches a host regardless of port', () => {
+      const pattern = new NetworkHostPattern('*.vendor.com:443');
+
+      expect(pattern.validateHostname('api.vendor.com')).toBe(true);
+    });
+
+    it('does not match an unrelated host', () => {
+      const pattern = new NetworkHostPattern('*.vendor.com:443');
+
+      expect(pattern.validateHostname('vendor.com')).toBe(false);
+    });
+  });
+
   describe('IPv6 patterns', () => {
     const exactIpv6Pattern = new NetworkHostPattern('[fd00::1]:443');
 

--- a/packages/javascript/src/utils/NetworkHostPattern.ts
+++ b/packages/javascript/src/utils/NetworkHostPattern.ts
@@ -28,10 +28,11 @@ export class NetworkHostPattern {
 
   /** Checks whether `host` and `port` are matched by this pattern. */
   validate(host: string, port: number): boolean {
-    return this.matchesHost(host) && (this.port === '*' || Number(this.port) === port);
+    return this.validateHostname(host) && (this.port === '*' || Number(this.port) === port);
   }
 
-  private matchesHost(host: string): boolean {
+  /** Checks whether `host` is matched by the hostname part of this pattern, ignoring the port. */
+  validateHostname(host: string): boolean {
     // Hostnames are case-insensitive; IP literals are unaffected by lowercasing.
     const patternHost = this.host.toLowerCase();
     host = host.toLowerCase();


### PR DESCRIPTION
This is useful for certifcate checks in COGS, which are not aware of the port number of the request
