### PR TITLE
Fix plugin manifest validation for `caCertificates` in network rules

### DIFF
--- a/packages/javascript/src/utils/getPluginManifestErrors.test.ts
+++ b/packages/javascript/src/utils/getPluginManifestErrors.test.ts
@@ -151,6 +151,26 @@ describe('validate plugin manifest', () => {
           }),
         ).toHaveLength(1);
       });
+
+      test('network access rule with reference to a caCertificates file', () => {
+        expect(
+          getPluginManifestErrors({
+            name: 'test plugin',
+            version: '0.0.1',
+            minCogsVersion: '5.11.0',
+            permissions: {
+              network: {
+                access: [
+                  {
+                    hosts: ['private:443'],
+                    caCertificates: ['certs/https_self_signed_cert.pem'],
+                  },
+                ],
+              },
+            },
+          }),
+        ).toBeNull();
+      });
     });
   });
 });

--- a/packages/javascript/src/utils/getPluginManifestErrors.ts
+++ b/packages/javascript/src/utils/getPluginManifestErrors.ts
@@ -174,7 +174,7 @@ function createManifestSchema(objectSchemaFactory: typeof z.strictObject | typeo
               .array(
                 objectSchemaFactory({
                   hosts: z.array(z.string().refine(validateNetworkHostPattern, { error: 'Invalid network host pattern' })).min(1),
-                  caCertificate: z.string().optional(),
+                  caCertificates: z.array(z.string().min(1)).optional(),
                 }),
               )
               .optional(),


### PR DESCRIPTION
Fixes `Unrecognized key: caCertificates`.