### PR TITLE
Adding AudioBlobCache

### DIFF
--- a/packages/javascript/cypress.config.ts
+++ b/packages/javascript/cypress.config.ts
@@ -5,7 +5,7 @@ const sharp = require('sharp');
 
 import { rename } from 'node:fs/promises';
 
-import { startTestFileServer } from './cypress/support/testFileServer';
+import { startDelayedFileServer } from './cypress/support/delayedFileServer';
 
 export default defineConfig({
   defaultBrowser: 'electron',
@@ -16,7 +16,7 @@ export default defineConfig({
         'get-pixel-value': getPixelValue,
       });
 
-      const testFileServer = await startTestFileServer();
+      const testFileServer = await startDelayedFileServer();
       on('after:run', () => testFileServer.close());
     },
     devServer: {

--- a/packages/javascript/cypress.config.ts
+++ b/packages/javascript/cypress.config.ts
@@ -5,14 +5,19 @@ const sharp = require('sharp');
 
 import { rename } from 'node:fs/promises';
 
+import { startTestFileServer } from './cypress/support/testFileServer';
+
 export default defineConfig({
   defaultBrowser: 'electron',
   component: {
-    setupNodeEvents(on) {
+    async setupNodeEvents(on) {
       on('after:screenshot', flattenScreenshots);
       on('task', {
         'get-pixel-value': getPixelValue,
       });
+
+      const testFileServer = await startTestFileServer();
+      on('after:run', () => testFileServer.close());
     },
     devServer: {
       framework: 'react',

--- a/packages/javascript/cypress/component/AudioBlobCache.cy.ts
+++ b/packages/javascript/cypress/component/AudioBlobCache.cy.ts
@@ -1,0 +1,76 @@
+import { AudioBlobCache } from '../../src/state-based/AudioBlobCache';
+import { createTestURL } from '../support/delayedFileServerConfig';
+
+function playAndMeasureTimeToPlaying(element: HTMLAudioElement): Promise<number> {
+  const startedAt = performance.now();
+  document.body.append(element);
+  element.play().catch(() => {
+    /* do nothing */
+  });
+
+  return new Promise((resolve) => {
+    if (element.currentTime > 0) {
+      resolve(performance.now() - startedAt);
+    } else {
+      element.addEventListener('playing', () => resolve(performance.now() - startedAt), { once: true, passive: true });
+    }
+  });
+}
+
+let cleanup: () => void = () => {
+  /* replace with cleanup */
+};
+
+describe('AudioBlobCache', () => {
+  beforeEach(() => cleanup());
+
+  it(`doesn't speed up new fetching`, async () => {
+    const cache = new AudioBlobCache();
+    const url = createTestURL('sinwave@440hz.wav', { delayMs: 200 });
+
+    const { element, revoke } = cache.getElement(url);
+    cleanup = revoke;
+
+    const timeToPlaying = await playAndMeasureTimeToPlaying(element);
+    expect(timeToPlaying).to.be.at.least(200);
+  });
+
+  it('speeds up cached playback', async () => {
+    const cache = new AudioBlobCache();
+    const url = createTestURL('sinwave@440hz.wav', { delayMs: 200 });
+
+    await cache.preFetch([url]);
+
+    const { element, revoke } = cache.getElement(url);
+    cleanup = revoke;
+
+    const timeToPlaying = await playAndMeasureTimeToPlaying(element);
+    expect(timeToPlaying).to.be.lessThan(100);
+  });
+
+  it('gracefully handles failed fetches', async () => {
+    const cache = new AudioBlobCache();
+    const url = createTestURL('sinwave@440hz.wav', { fail: true });
+
+    await cache.preFetch([url]);
+
+    const { element, revoke } = cache.getElement(url);
+    cleanup = revoke;
+
+    expect(element.tagName).to.equal('AUDIO');
+    expect(element.src).to.equal(url);
+  });
+
+  it("revoke() doesn't break an element already playing from that URL", async () => {
+    const cache = new AudioBlobCache();
+    const url = createTestURL('sinwave@440hz.wav');
+
+    await cache.preFetch([url]);
+
+    const { element, revoke } = cache.getElement(url);
+    cleanup = revoke;
+    await playAndMeasureTimeToPlaying(element);
+
+    expect(element.paused).to.equal(false);
+  });
+});

--- a/packages/javascript/cypress/component/AudioStability.cy.ts
+++ b/packages/javascript/cypress/component/AudioStability.cy.ts
@@ -69,7 +69,7 @@ describe('Audio stability tests', () => {
     cy.log('Interfere with audio element');
     cy.get('audio').invoke('prop', 'playbackRate').should('equal', 0);
     cy.get('audio').invoke('prop', 'playbackRate', 1);
-    cy.get('audio').then(($audio) => $audio.get(0).play().catch(/* do nothing*/));
+    cy.get('audio').then(($audio) => $audio.get(0).play().catch(/* do nothing */));
 
     cy.wait(1000);
 

--- a/packages/javascript/cypress/component/TestFileServer.cy.ts
+++ b/packages/javascript/cypress/component/TestFileServer.cy.ts
@@ -1,0 +1,25 @@
+import { createTestURL } from '../support/delayedFileServerConfig';
+
+describe('Test delaye server', () => {
+  it('delays a response by the requested delayMs before the audio element can play', () => {
+    const url = createTestURL('sinwave@440hz.wav', { delayMs: 200 });
+
+    let requestedAt = 0;
+    cy.then(() => {
+      requestedAt = performance.now();
+      const audio = document.createElement('audio');
+      audio.src = url;
+      document.body.append(audio);
+      audio.play().catch(() => {
+        /* do nothing */
+      });
+    });
+
+    cy.get('audio')
+      .invoke('prop', 'currentTime')
+      .should(($time) => expect(parseFloat($time)).to.be.greaterThan(0))
+      .then(() => {
+        expect(performance.now() - requestedAt).to.be.at.least(200);
+      });
+  });
+});

--- a/packages/javascript/cypress/component/TestFileServer.cy.ts
+++ b/packages/javascript/cypress/component/TestFileServer.cy.ts
@@ -1,6 +1,6 @@
 import { createTestURL } from '../support/delayedFileServerConfig';
 
-describe('Test delaye server', () => {
+describe('Test delayed server', () => {
   it('delays a response by the requested delayMs before the audio element can play', () => {
     const url = createTestURL('sinwave@440hz.wav', { delayMs: 200 });
 

--- a/packages/javascript/cypress/component/VideoStability.cy.ts
+++ b/packages/javascript/cypress/component/VideoStability.cy.ts
@@ -72,7 +72,7 @@ describe('Video stability tests', () => {
     cy.log('Interfere with video element');
     cy.get('video').invoke('prop', 'playbackRate').should('equal', 0);
     cy.get('video').invoke('prop', 'playbackRate', 1);
-    cy.get('video').then(($video) => $video.get(0).play().catch(/* do nothing*/));
+    cy.get('video').then(($video) => $video.get(0).play().catch(/* do nothing */));
 
     cy.wait(1000);
 

--- a/packages/javascript/cypress/support/delayedFileServer.ts
+++ b/packages/javascript/cypress/support/delayedFileServer.ts
@@ -15,7 +15,7 @@ const MIME_TYPES: Record<string, string> = {
   '.png': 'image/png',
 };
 
-export function startTestFileServer(): Promise<{ close: () => Promise<void> }> {
+export function startDelayedFileServer(): Promise<{ close: () => Promise<void> }> {
   const server = http.createServer((req, res) => {
     const requestUrl = new URL(req.url ?? '/', `http://localhost:${PORT}`);
     const delayMs = Number(requestUrl.searchParams.get('delayMs') ?? '0');

--- a/packages/javascript/cypress/support/delayedFileServer.ts
+++ b/packages/javascript/cypress/support/delayedFileServer.ts
@@ -1,0 +1,54 @@
+// Node-only. Imported exclusively by cypress.config.ts's setupNodeEvents - never by a spec
+// file or anything Vite bundles for the browser.
+
+import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { PORT } from './delayedFileServerConfig';
+
+const FIXTURES_DIR = path.join(__dirname, '../fixtures');
+
+const MIME_TYPES: Record<string, string> = {
+  '.wav': 'audio/wav',
+  '.mp4': 'video/mp4',
+  '.png': 'image/png',
+};
+
+export function startTestFileServer(): Promise<{ close: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    const requestUrl = new URL(req.url ?? '/', `http://localhost:${PORT}`);
+    const delayMs = Number(requestUrl.searchParams.get('delayMs') ?? '0');
+    const shouldFail = requestUrl.searchParams.get('fail') === 'true';
+
+    setTimeout(() => {
+      if (shouldFail) {
+        req.socket.destroy();
+        return;
+      }
+
+      const filePath = path.join(FIXTURES_DIR, decodeURIComponent(requestUrl.pathname));
+      fs.readFile(filePath, (err, data) => {
+        if (err) {
+          res.writeHead(404, { 'Access-Control-Allow-Origin': '*' });
+          res.end();
+          return;
+        }
+        res.writeHead(200, {
+          'Content-Type': MIME_TYPES[path.extname(filePath)] ?? 'application/octet-stream',
+          'Access-Control-Allow-Origin': '*',
+        });
+        res.end(data);
+      });
+    }, delayMs);
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(PORT, () => {
+      resolve({
+        close: () => new Promise((resolveClose) => server.close(() => resolveClose())),
+      });
+    });
+  });
+}

--- a/packages/javascript/cypress/support/delayedFileServerConfig.ts
+++ b/packages/javascript/cypress/support/delayedFileServerConfig.ts
@@ -1,0 +1,9 @@
+export const PORT = 4567;
+
+export function createTestURL(file: string, options: { delayMs?: number; fail?: boolean } = {}): string {
+  const params = new URLSearchParams();
+  if (options.delayMs) params.set('delayMs', String(options.delayMs));
+  if (options.fail) params.set('fail', 'true');
+  const query = params.toString();
+  return `http://localhost:${PORT}/${file}${query ? `?${query}` : ''}`;
+}

--- a/packages/javascript/src/state-based/AudioBlobCache.ts
+++ b/packages/javascript/src/state-based/AudioBlobCache.ts
@@ -1,0 +1,27 @@
+import { BlobCache } from './BlobCache';
+
+export class AudioBlobCache {
+  private _blobCache = new BlobCache();
+
+  preFetch(urls: string[]): Promise<void> {
+    return this._blobCache.preFetch(urls);
+  }
+
+  getElement(url: string): { element: HTMLAudioElement; revoke: () => void } {
+    const cacheHit = this._blobCache.getUrl(url);
+
+    const { url: src, revoke } = cacheHit ?? {
+      url,
+      revoke: () => {
+        /* do nothing */
+      },
+    };
+    const element = document.createElement('audio');
+    element.src = src;
+    return { element, revoke };
+  }
+
+  destroy(): void {
+    this._blobCache.destroy();
+  }
+}

--- a/packages/javascript/src/state-based/BlobCache.ts
+++ b/packages/javascript/src/state-based/BlobCache.ts
@@ -4,7 +4,7 @@ const CACHE_SIZE = 200 * 1024 * 1024;
  * Fetches files and holds them as `Blob`s so they can be served back out as object URLs with
  */
 export class BlobCache {
-  private _size = 0;
+  private _sizeBytes = 0;
   private _cache = new Map<string, Blob>();
   private _activeAbort: AbortController | null = null;
 
@@ -19,7 +19,7 @@ export class BlobCache {
       if (!newURLs.has(prevURL)) {
         const staleBlob = this._cache.get(prevURL);
         if (staleBlob) {
-          this._size -= staleBlob.size;
+          this._sizeBytes -= staleBlob.size;
           this._cache.delete(prevURL);
         }
       }
@@ -53,10 +53,10 @@ export class BlobCache {
       }
 
       if (signal.aborted) return;
-      if (this._size + blob.size > CACHE_SIZE) break;
+      if (this._sizeBytes + blob.size > CACHE_SIZE) break;
 
       this._cache.set(url, blob);
-      this._size += blob.size;
+      this._sizeBytes += blob.size;
     }
   }
 

--- a/packages/javascript/src/state-based/BlobCache.ts
+++ b/packages/javascript/src/state-based/BlobCache.ts
@@ -1,0 +1,76 @@
+const CACHE_SIZE = 200 * 1024 * 1024;
+
+/**
+ * Fetches files and holds them as `Blob`s so they can be served back out as object URLs with
+ */
+export class BlobCache {
+  private _size = 0;
+  private _cache = new Map<string, Blob>();
+  private _activeAbort: AbortController | null = null;
+
+  async preFetch(urls: string[]): Promise<void> {
+    this._activeAbort?.abort();
+
+    const controller = new AbortController();
+    this._activeAbort = controller;
+
+    const newURLs = new Set(urls);
+    for (const prevURL of this._cache.keys()) {
+      if (!newURLs.has(prevURL)) {
+        const staleBlob = this._cache.get(prevURL);
+        if (staleBlob) {
+          this._size -= staleBlob.size;
+          this._cache.delete(prevURL);
+        }
+      }
+    }
+
+    const abortRejection = new Promise<never>((_resolve, reject) => {
+      controller.signal.addEventListener('abort', () => reject(new Error('preFetch superseded by a newer call')));
+    });
+
+    try {
+      await Promise.race([this._runPreFetch(urls, controller.signal), abortRejection]);
+    } finally {
+      if (this._activeAbort === controller) {
+        this._activeAbort = null;
+      }
+    }
+  }
+
+  private async _runPreFetch(urls: string[], signal: AbortSignal): Promise<void> {
+    for (const url of urls) {
+      if (signal.aborted) return;
+      if (this._cache.has(url)) continue;
+
+      let blob: Blob;
+      try {
+        const response = await fetch(url, { signal });
+        if (!response.ok) continue;
+        blob = await response.blob();
+      } catch {
+        continue;
+      }
+
+      if (signal.aborted) return;
+      if (this._size + blob.size > CACHE_SIZE) break;
+
+      this._cache.set(url, blob);
+      this._size += blob.size;
+    }
+  }
+
+  getUrl(url: string): { url: string; revoke: () => void } | undefined {
+    const blob = this._cache.get(url);
+    if (blob) {
+      const objectUrl = URL.createObjectURL(blob);
+      return { url: objectUrl, revoke: () => URL.revokeObjectURL(objectUrl) };
+    }
+  }
+
+  destroy(): void {
+    this._activeAbort?.abort();
+    this._activeAbort = null;
+    this._cache.clear();
+  }
+}

--- a/packages/javascript/src/state-based/MediaClipManager.ts
+++ b/packages/javascript/src/state-based/MediaClipManager.ts
@@ -223,7 +223,7 @@ function assertPlaybackRate(mediaElement: HTMLMediaElement, playbackRate: number
   // On iOS it doesn't make a difference, so we may as well.
   if (mediaElement.paused) {
     mediaElement.play().catch(() => {
-      /* do nothing*/
+      /* do nothing */
     });
   }
 }


### PR DESCRIPTION
- Adds a BlobCache that fetches data and stores as blobs
- Adds AudioBlobCache (thin wrapper) that prepares HTMLAudioElements
- Adds test suite and test server
- Currently unused, but will be piped into the rest of the MediaPreloader in the next PR